### PR TITLE
style(demo): fix demo code formatting

### DIFF
--- a/src/test/java/com/flowingcode/vaadin/addons/badgelist/StyledBadgesDemo.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/badgelist/StyledBadgesDemo.java
@@ -37,6 +37,7 @@ import java.util.List;
 public class StyledBadgesDemo extends BaseBadgeListDemo {
 
   public StyledBadgesDemo() {
+
     // begin-block example1
     List<Badge> badges1 = new ArrayList<>();
     for (int i = 0; i < 8; i++) {
@@ -94,6 +95,7 @@ public class StyledBadgesDemo extends BaseBadgeListDemo {
     // #endif
     // show-source add(layout3);
     // end-block
+
   }
 
   // #if vaadin eq 0
@@ -101,5 +103,6 @@ public class StyledBadgesDemo extends BaseBadgeListDemo {
     Icon icon = vaadinIcon.create();
     icon.getStyle().set("padding", "var(--lumo-space-xs");
     return icon;
-  } // #endif
+  }
+  // #endif
 }


### PR DESCRIPTION
Added some blank lines before/after each code block. There was also an `#endif` directive that must be in a new line (a bracket was not rendered)
![image](https://github.com/FlowingCode/BadgeList/assets/11554739/828cf107-7ea5-4ae6-8995-96527b3db1a1)
