### PR TITLE
fix: don't render empty label

### DIFF
--- a/src/main/resources/META-INF/resources/frontend/src/fc-badge-list.ts
+++ b/src/main/resources/META-INF/resources/frontend/src/fc-badge-list.ts
@@ -85,6 +85,10 @@ export class BadgeList extends ResizeMixin(ThemableMixin(LitElement)) {
       margin: var(--badge-list-badges-margin);
     }   
 
+    :host(:not([has-label])) [part='label']{
+      display:none;
+    }
+
     [part="label"] {
       align-self: flex-start;
       color: var(--badge-list-label-color);
@@ -229,6 +233,13 @@ export class BadgeList extends ResizeMixin(ThemableMixin(LitElement)) {
       	</vaadin-context-menu>        
       </div>
     `;
+  }
+  
+  update(_changedProperties: Map<PropertyKey, unknown>) {
+    if (_changedProperties.has('label')) {
+      this.toggleAttribute('has-label', this.label != null);
+    }
+    super.update(_changedProperties);
   }
 
 }


### PR DESCRIPTION
Close #23

Adds "has-label" attribute to control the rendering of the label.

This can be tested in ReadOnlyBinderDemo in which the BadgeList component adds a label and, inspecting the DOM will show this component has the "has-label" attribute and so the label is being rendered. The opposite can be tested in the other two demo views in which the BadgeList components are not expected to render a label, so no "has-label" attribute is present and no empty label is present either.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced badge list component to manage badge visibility more effectively.
	- Introduced a mechanism to hide the label when not present, improving UI clarity.
	- Updated overflow handling to ensure hidden badges are accessible through an overflow menu.

- **Bug Fixes**
	- Improved rendering logic to ensure labels are only displayed when they have a value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->