### PR TITLE
build(demo): add dependency to commons-demo-processor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -482,6 +482,14 @@
 					</plugin>
 				</plugins>
 			</build>
+			<dependencies>
+				<dependency>
+					<groupId>com.flowingcode.vaadin.addons.demo</groupId>
+					<artifactId>commons-demo-processor</artifactId>
+					<version>${flowingcode.commons.demo.version}</version>
+					<scope>provided</scope>
+				</dependency>
+			</dependencies>
 		</profile>
 
         	<profile>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<drivers.dir>${project.basedir}/drivers</drivers.dir>
 		<jetty.version>11.0.26</jetty.version>
-		<flowingcode.commons.demo.version>5.2.0</flowingcode.commons.demo.version>
+		<flowingcode.commons.demo.version>5.3.0</flowingcode.commons.demo.version>
 		<frontend.hotdeploy>true</frontend.hotdeploy>
 	</properties>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped demo dependency version to 5.3.0 and adjusted the build profile to declare the demo processor as provided scope.
  * No runtime or public API changes; this update affects build configuration only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->