### PR TITLE
build(demo): point github branch to 1.x

### DIFF
--- a/src/test/java/com/flowingcode/vaadin/addons/badgelist/BadgeListDemoView.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/badgelist/BadgeListDemoView.java
@@ -32,7 +32,7 @@ import com.vaadin.flow.router.Route;
 @Route("badge-list")
 @GithubLink("https://github.com/FlowingCode/BadgeList")
 @CssImport("./styles/badge-list-demo-styles.css")
-@GithubBranch("master")
+@GithubBranch("1.x")
 public class BadgeListDemoView extends TabbedDemo {
 
   public BadgeListDemoView() {


### PR DESCRIPTION
## Summary
- Update `@GithubBranch` on `BadgeListDemoView` from `master` to `1.x` so the demo fetches source examples from the 1.x maintenance branch.

## Context
`master` has moved on to the 2.x major version, so the existing `@GithubBranch("master")` causes AddonsDemo's `GithubBranchTest` to fail for `badgelist.BadgeListDemoView` with a major-version mismatch (1.x pinned, 2.x on master).

## Test plan
- [ ] CI on this branch passes.
- [ ] After a new 1.2.1-SNAPSHOT demo jar is deployed, `GithubBranchTest` in AddonsDemo's `vaadin24` build passes for `BadgeListDemoView`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)