### PR TITLE
Document Badge component experimental feature and exclude feature flags from jar

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,19 @@ Badge List Add-on is written by Flowing Code S.A.
 
 # Developer Guide
 
+## Enabling the Badge component
+
+Since version 2.0.0, this add-on uses the preview version of Badge component from Vaadin core (`com.vaadin.flow.component.badge.Badge`). As is currently an experimental feature it must be explicitly enabled in your project before using this add-on.
+
+You can enable it in one of two ways:
+
+- Through **Vaadin Copilot**, in the experimental features panel.
+- By adding the following line to `src/main/resources/vaadin-featureflags.properties` in your project:
+
+```properties
+com.vaadin.experimental.badgeComponent=true
+```
+
 ## Getting started
 
 ```java

--- a/pom.xml
+++ b/pom.xml
@@ -310,6 +310,7 @@
 							<!-- Generated file that shouldn't be included in add-ons -->
 							<excludes>
 								<exclude>META-INF/VAADIN/config/flow-build-info.json</exclude>
+								<exclude>**/vaadin-featureflags.properties</exclude>
 							</excludes>
 						</configuration>
 					</plugin>


### PR DESCRIPTION
- Documents that since version 2.x, this add-on uses the preview Badge component from Vaadin core, which must be explicitly enabled as an experimental feature.
- Excludes vaadin-featureflags.properties from the packaged add-on JAR to prevent distributing project-specific feature flag configuration.

Close #43

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added instructions for enabling the Badge component, now available as an experimental feature starting from version 2.0.0. Users can enable it via the experimental features panel or through feature flag configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->