### PR TITLE
Use explicit marginInlineStart/End for overflow badge

### DIFF
--- a/src/main/resources/META-INF/resources/frontend/src/fc-badge-list.ts
+++ b/src/main/resources/META-INF/resources/frontend/src/fc-badge-list.ts
@@ -203,7 +203,7 @@ export class BadgeList extends ResizeMixin(ThemableMixin(ThemeDetectionMixin(Lit
     // Reset overflow badge for overflow calculations and get width
     overflow.removeAttribute("hidden");
     let overflowStyle = getComputedStyle(overflow);
-    let overflowWidth = overflow.offsetWidth + parseInt(overflowStyle.marginInline);
+    let overflowWidth = overflow.offsetWidth + parseInt(overflowStyle.marginInlineStart) + parseInt(overflowStyle.marginInlineEnd);
 
     // Reset badges for calculations
     badges.forEach(badge => {


### PR DESCRIPTION
Close #41

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed badge overflow calculations to accurately determine available horizontal space, ensuring badges display or overflow correctly based on actual container dimensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->