### PR TITLE
Remove badgeComponent experimental flag requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Responsive badge list component.
 ## Supported versions
 
 Supported versions: Vaadin 24-25 (add-on version 1.x)
-Supported versions: Vaadin 25.1+ (add-on version 2.x)
+Supported versions: Vaadin 25.1 (add-on version 2.0)
+Supported versions: Vaadin 25.2+ (add-on version 2.1)
 
 ## Online demo
 
@@ -103,19 +104,6 @@ This add-on is distributed under Apache License 2.0. For license terms, see LICE
 Badge List Add-on is written by Flowing Code S.A.
 
 # Developer Guide
-
-## Enabling the Badge component
-
-Since version 2.0.0, this add-on uses the preview version of Badge component from Vaadin core (`com.vaadin.flow.component.badge.Badge`). As is currently an experimental feature it must be explicitly enabled in your project before using this add-on.
-
-You can enable it in one of two ways:
-
-- Through **Vaadin Copilot**, in the experimental features panel.
-- By adding the following line to `src/main/resources/vaadin-featureflags.properties` in your project:
-
-```properties
-com.vaadin.experimental.badgeComponent=true
-```
 
 ## Getting started
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,13 +4,13 @@
 
 	<groupId>com.flowingcode.vaadin.addons</groupId>
 	<artifactId>badge-list-addon</artifactId>
-	<version>2.0.1-SNAPSHOT</version>
+	<version>2.1.0-SNAPSHOT</version>
 	<name>Badge List Add-on</name>
 	<description>Badge List Add-on for Vaadin Flow</description>
 	<url>https://www.flowingcode.com/en/open-source/</url>
 	
 	<properties>
-        <vaadin.version>25.1.1</vaadin.version>
+        <vaadin.version>25.2.1</vaadin.version>
         <selenium.version>4.10.0</selenium.version>
 		<maven.compiler.source>21</maven.compiler.source>
 		<maven.compiler.target>21</maven.compiler.target>
@@ -310,7 +310,6 @@
 							<!-- Generated file that shouldn't be included in add-ons -->
 							<excludes>
 								<exclude>META-INF/VAADIN/config/flow-build-info.json</exclude>
-								<exclude>**/vaadin-featureflags.properties</exclude>
 							</excludes>
 						</configuration>
 					</plugin>

--- a/src/main/resources/vaadin-featureflags.properties
+++ b/src/main/resources/vaadin-featureflags.properties
@@ -1,1 +1,0 @@
-com.vaadin.experimental.badgeComponent=true


### PR DESCRIPTION
The Badge component is stable and non-experimental as of Vaadin 25.2, so the badgeComponent feature flag is no longer needed to use this add-on.

- Delete src/main/resources/vaadin-featureflags.properties
- Upgrade vaadin.version to 25.2.1
- Drop the now-orphan vaadin-featureflags.properties jar exclusion
- Bump add-on version to 2.1.0-SNAPSHOT
- Update README supported versions and remove the flag-enabling section

Close #49

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified supported Vaadin version compatibility with explicit mappings for add-on versions 2.0 and 2.1.
  * Removed outdated setup guidance for the badge component.

* **Chores**
  * Updated the add-on to the 2.1.0 release line and aligned it with a newer Vaadin platform version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->